### PR TITLE
Fix data import to postgres db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Python env
+venv
+# Pycharm
+.idea
+.DS_Store

--- a/Data_Modeling_with_Postgres/etl.py
+++ b/Data_Modeling_with_Postgres/etl.py
@@ -13,7 +13,7 @@ def process_song_file(cur, filepath):
     """
 
     # open song file
-    df = pd.DataFrame([pd.read_json(filepath, typ='series')])
+    df = pd.DataFrame([pd.read_json(filepath, typ='series', convert_dates=False)])
 
     for value in df.values:
         num_songs, artist_id, artist_latitude, artist_longitude, artist_location, artist_name, song_id, title, duration, year = value
@@ -39,7 +39,7 @@ def process_log_file(cur, filepath):
     df = df = pd.read_json(filepath, lines=True)
 
     # filter by NextSong action
-    df = df[df['page'] == "NextSong"].astype({'ts' : 'datetime64[ns]'})
+    df = df[df['page'] == "NextSong"].astype({'ts': 'datetime64[ms]'})
 
     # convert timestamp column to datetime
     t = pd.Series(df['ts'], index=df.index)


### PR DESCRIPTION
Added gitignore

_convert_dates=False_ added setting is to prevent `TypeError: invalid string coercion to datetime`

datetime64 changed from nanoseconds to miliseconds, which is what is used in the log files. Without this, the data is imported, but the log timestamps are all in year 1970, instead of 2018.
